### PR TITLE
Fixed missing context based timeouts on WaitUntilReady method calls.

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/couchbase/gocb/v2"
 	"github.com/hashicorp/errwrap"
@@ -99,7 +98,7 @@ func (c *couchbaseDBConnectionProducer) Initialize(ctx context.Context, config m
 	_, err := c.Init(ctx, config, verifyConnection)
 	return err
 }
-func (c *couchbaseDBConnectionProducer) Connection(_ context.Context) (interface{}, error) {
+func (c *couchbaseDBConnectionProducer) Connection(ctx context.Context) (interface{}, error) {
 	// This is intentionally not grabbing the lock since the calling functions (e.g. CreateUser)
 	// are claiming it. (The locking patterns could be refactored to be more consistent/clear.)
 
@@ -147,12 +146,12 @@ func (c *couchbaseDBConnectionProducer) Connection(_ context.Context) (interface
 	if c.BucketName != "" {
 		bucket := c.cluster.Bucket(c.BucketName)
 		// We wait until the bucket is definitely connected and setup.
-		err = bucket.WaitUntilReady(5*time.Second, nil)
+		err = bucket.WaitUntilReady(computeTimeout(ctx), nil)
 		if err != nil {
 			return nil, errwrap.Wrapf("error in Connection waiting for bucket: {{err}}", err)
 		}
 	} else {
-		err = c.cluster.WaitUntilReady(5*time.Second, nil)
+		err = c.cluster.WaitUntilReady(computeTimeout(ctx), nil)
 
 		if err != nil {
 			return nil, errwrap.Wrapf("error in Connection waiting for cluster: {{err}}", err)

--- a/couchbase.go
+++ b/couchbase.go
@@ -18,6 +18,7 @@ import (
 const (
 	couchbaseTypeName        = "couchbase"
 	defaultCouchbaseUserRole = `{"Roles": [{"role":"ro_admin"}]}`
+	defaultTimeout           = 20000 * time.Millisecond
 )
 
 var (
@@ -86,7 +87,7 @@ func computeTimeout(ctx context.Context) (timeout time.Duration) {
 	if ok {
 		return time.Until(deadline)
 	}
-	return 5 * time.Second
+	return defaultTimeout
 }
 func (c *CouchbaseDB) getConnection(ctx context.Context) (*gocb.Cluster, error) {
 	db, err := c.Connection(ctx)

--- a/couchbase_test.go
+++ b/couchbase_test.go
@@ -762,12 +762,12 @@ func testConnectionProducerSecretValues(t *testing.T) {
 
 func testComputeTimeout(t *testing.T) {
 	t.Log("Testing computeTimeout")
-	if computeTimeout(context.Background()) != 5000*time.Millisecond {
-		t.Fatalf("Background timeout not set to 5 seconds.")
+	if computeTimeout(context.Background()) != defaultTimeout {
+		t.Fatalf("Background timeout not set to %s milliseconds.", defaultTimeout)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	if computeTimeout(ctx) == 5000*time.Millisecond {
+	if computeTimeout(ctx) == defaultTimeout {
 		t.Fatal("WithTimeout failed")
 	}
 }


### PR DESCRIPTION
Missed these two gocb WaitUntilReady client calls that had a short hard coded timeout set which were causing the flakiness in the automated tests.