### PR TITLE
Add testacc make target and use it in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       docker_layer_caching: true
     environment:
       GO_VERSION: 1.14.4
-      VAULT_ACC: true
+      GO_TEST_CMD: gotestsum --format=short-verbose --junitfile=test-results/go-test/$${COUCHBASE_VERSION}-results.xml --jsonfile=test-results/go-test/$${COUCHBASE_VERSION}-results.json --
+      GOTESTSUM_VERSION: 0.5.2
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
@@ -30,12 +31,22 @@ jobs:
 
           echo "$ go version"
           go version
+
+          # Install gotestsum
+          curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar --overwrite -xz -C /usr/local/bin gotestsum
+
         name: Setup Go
         working_directory: ~/
-
     - checkout
-    # specify any bash command here prefixed with `run: `
-    - run: go get -v -t -d ./...
-    - run: COUCHBASE_VERSION=6.5.0 go test -v ./...
-    - run: COUCHBASE_VERSION=6.0.0 go test -v ./...
-    - run: COUCHBASE_VERSION=5.5.1 go test -v ./...
+    - run:
+        command: |
+          mkdir -p test-results/go-test
+          COUCHBASE_VERSION=6.5.0 make testacc
+          COUCHBASE_VERSION=6.0.0 make testacc
+          COUCHBASE_VERSION=5.5.1 make testacc
+        name: Run Go tests
+    - store_artifacts:
+        path: test-results
+    - store_test_results:
+        path: test-results

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: fmtcheck
 
 # test runs the unit tests and vets the code
 test: fmtcheck
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= ${GO_TEST_CMD} -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=5m -parallel=4
+	CGO_ENABLED=0 VAULT_TOKEN= ${GO_TEST_CMD} -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=5m -parallel=4
 
 testacc: fmtcheck
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 ${GO_TEST_CMD} -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ TEST?=$$(go list ./... | grep -v /vendor/ | grep -v teamcity)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+GO_TEST_CMD?=go test -v
 
 # bin generates the releaseable binaries for this plugin
-bin: fmtcheck generate
+bin: fmtcheck
 	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
 
 default: dev
@@ -13,14 +14,17 @@ default: dev
 # dev starts up `vault` from your $PATH, then builds the couchbase
 # plugin, registers it with vault and enables it.
 # A ./tmp dir is created for configs and binaries, and cleaned up on exit.
-dev: fmtcheck generate
+dev: fmtcheck
 	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # test runs the unit tests and vets the code
-test: fmtcheck generate
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+test: fmtcheck
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= ${GO_TEST_CMD} -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=5m -parallel=4
 
-testcompile: fmtcheck generate
+testacc: fmtcheck
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 ${GO_TEST_CMD} -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m
+
+testcompile: fmtcheck
 	@for pkg in $(TEST) ; do \
 		go test -v -c -tags='$(BUILD_TAGS)' $$pkg ; \
 	done


### PR DESCRIPTION
- Delete undefined `generate` target
- Separate test targets into `test` and `testacc` like we have in other repos
- Use `make testacc` in CI
- Use `gotestsum` for better test reporting UI in CircleCI