### PR TITLE
Added 6.6.0 and 6.5.1 release images to the test suite.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
     - run:
         command: |
           mkdir -p test-results/go-test
+          COUCHBASE_VERSION=6.6.0 make testacc
+          COUCHBASE_VERSION=6.5.1 make testacc
           COUCHBASE_VERSION=6.5.0 make testacc
           COUCHBASE_VERSION=6.0.0 make testacc
           COUCHBASE_VERSION=5.5.1 make testacc


### PR DESCRIPTION
Hi, I asked Couchbase to create the sandbox images for the two latest releases of their database and they did, so here they are added to the test suite. I left the existing older version in the mix as I think they are still widely used.