### PR TITLE
template: change default template to truncate username at 128 chars

### DIFF
--- a/couchbase.go
+++ b/couchbase.go
@@ -21,7 +21,7 @@ const (
 	defaultCouchbaseUserRole = `{"Roles": [{"role":"ro_admin"}]}`
 	defaultTimeout           = 20000 * time.Millisecond
 
-	defaultUserNameTemplate = `V_{{.DisplayName | uppercase | truncate 64}}_{{.RoleName | uppercase | truncate 64}}_{{random 20 | uppercase}}_{{unix_time}}`
+	defaultUserNameTemplate = `{{printf "V_%s_%s_%s_%s" (printf "%s" .DisplayName | uppercase | truncate 64) (printf "%s" .RoleName | uppercase | truncate 64) (random 20 | uppercase) (unix_time) | truncate 128}}`
 )
 
 var _ dbplugin.Database = &CouchbaseDB{}


### PR DESCRIPTION
Change the default template to truncate usernames at 128 characters since this is the hard cap on Couchbase according to [their docs](https://docs.couchbase.com/server/current/learn/security/usernames-and-passwords.html#usernames-and-roles).

Previous to Vault 1.7.0 (before username customization support got added to this engine), the generation of usernames went through `credsutil.GenerateUsername`, which had an [internal cap of 100 characters](https://github.com/hashicorp/vault/blob/51f668e4ae035b26cfae87a90197e34a18fb8970/sdk/database/helper/credsutil/usernames.go#L94) for username that it generates, thus preventing this issue from occurring.