### PR TITLE
workflows: add bulk dep update job

### DIFF
--- a/.github/workflows/bulk-dep-upgrades.yaml
+++ b/.github/workflows/bulk-dep-upgrades.yaml
@@ -1,0 +1,17 @@
+name: Upgrade dependencies
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs 12:00AM on the first of every month
+    - cron: '0 0 1 * *'
+jobs:
+  upgrade:
+    # using `main` as the ref will keep your workflow up-to-date
+    uses: hashicorp/vault-workflows-common/.github/workflows/bulk-dependency-updates.yaml@main
+    secrets:
+      VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
+    with:
+      # either hashicorp/vault-ecosystem-applications or hashicorp/vault-ecosystem-foundations
+      reviewer-team: hashicorp/vault-ecosystem-applications
+      repository: ${{ github.repository }}
+      run-id: ${{ github.run_id }}


### PR DESCRIPTION
Add the bulk dep upgrade job from the common workflows. This will run on the first of each month.