### PR TITLE
allow custom username templates to use lowercase function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUG FIXES:
+* allow custom username templates to use the lowercase function (https://github.com/hashicorp/vault-plugin-database-couchbase/pull/81)
+
 ## v0.11.0
 IMPROVEMENTS:
 * Updated dependencies:

--- a/couchbase.go
+++ b/couchbase.go
@@ -97,7 +97,6 @@ func (c *CouchbaseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest) 
 	if err != nil {
 		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to generate username: %w", err)
 	}
-	username = strings.ToUpper(username)
 
 	db, err := c.getConnection(ctx)
 	if err != nil {
@@ -138,7 +137,6 @@ func (c *CouchbaseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserReq
 	mgr := db.Users()
 
 	err = mgr.DropUser(req.Username, nil)
-
 	if err != nil {
 		return dbplugin.DeleteUserResponse{}, err
 	}
@@ -208,7 +206,6 @@ func (c *CouchbaseDB) changeUserPassword(ctx context.Context, username, password
 			Timeout:    computeTimeout(ctx),
 			DomainName: "local",
 		})
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR proposes a change to allow custom username templates to use the lowercase function. Previously, the plugin always uses uppercase for role names and display names and ignores the lowercase function in username templates.