### PR TITLE
[CHANGELOG] Prepare for v0.16.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.16.1
+### March 20, 2026
+
+* Upgrade `golang.org` libs to resolve vulns (#117)
+* Automated dependency upgrades (#116)
+
 ## Unreleased
 ## v0.16.0
 ### March 16, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * Upgrade `golang.org` libs to resolve vulns (#117)
 * Automated dependency upgrades (#116)
 
-## Unreleased
 ## v0.16.0
 ### March 16, 2026
 


### PR DESCRIPTION
Changelog update for version [v0.16.1](https://github.com/hashicorp/vault-plugin-database-couchbase/releases/tag/v0.16.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23322807727

